### PR TITLE
Update Gradio UI look

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,3 +1,20 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+body {
+    font-family: 'Inter', sans-serif;
+    background: linear-gradient(180deg, #fafbff 0%, #f0f2f5 100%);
+}
+
+body.dark {
+    background: #1b1e22;
+}
+
+.gradio-container {
+    max-width: 1200px;
+    margin: auto;
+    padding-bottom: 2em;
+}
+
 .dark #open_folder_small {
     min-width: auto;
     flex-grow: 0;

--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -32,7 +32,12 @@ def initialize_ui_interface(config, headless, use_shell, release_info, readme_co
     css = read_file_content("./assets/style.css")
 
     # Create the main Gradio Blocks interface
-    ui_interface = gr.Blocks(css=css, title=f"Kohya_ss GUI {release_info}", theme=gr.themes.Default())
+    # Use a modern theme for a fresher look
+    ui_interface = gr.Blocks(
+        css=css,
+        title=f"Kohya_ss GUI {release_info}",
+        theme=gr.themes.Soft(),
+    )
     with ui_interface:
         # Create tabs for different functionalities
         with gr.Tab("Dreambooth"):


### PR DESCRIPTION
## Summary
- switch to gradio's Soft theme
- apply global CSS to use Inter font and centered layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c616a1ec88333b0e2027173546a91