### PR TITLE
Fix invalid escape sequence warnings

### DIFF
--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -1209,7 +1209,7 @@ def verify_image_folder_pattern(folder_path: str) -> bool:
         # Log an error message if the folder does not exist
         log.error(
             f"...the provided path '{folder_path}' is not a valid folder. "
-            "Please follow the folder structure documentation found at docs\image_folder_structure.md ..."
+            "Please follow the folder structure documentation found at docs/image_folder_structure.md ..."
         )
         # Return False to indicate that the folder pattern is not valid
         return False
@@ -1243,7 +1243,7 @@ def verify_image_folder_pattern(folder_path: str) -> bool:
         )
         # Log an error message suggesting to follow the folder structure documentation
         log.error(
-            f"...please follow the folder structure documentation found at docs\image_folder_structure.md ..."
+            f"...please follow the folder structure documentation found at docs/image_folder_structure.md ..."
         )
         # Return False to indicate that the folder pattern is not valid
         return False
@@ -1253,7 +1253,7 @@ def verify_image_folder_pattern(folder_path: str) -> bool:
         # Log an error message if no image folders are found
         log.error(
             f"...no image folders found in {folder_path}. "
-            "Please follow the folder structure documentation found at docs\image_folder_structure.md ..."
+            "Please follow the folder structure documentation found at docs/image_folder_structure.md ..."
         )
         # Return False to indicate that the folder pattern is not valid
         return False

--- a/kohya_gui/wd14_caption_gui.py
+++ b/kohya_gui/wd14_caption_gui.py
@@ -239,7 +239,7 @@ def gradio_wd14_caption_gui_tab(
 
             tag_replacement = gr.Textbox(
                 label="Tag replacement",
-                info="tag replacement in the format of `source1,target1;source2,target2; ...`. Escape `,` and `;` with `\`. e.g. `tag1,tag2;tag3,tag4`",
+                info=r"tag replacement in the format of `source1,target1;source2,target2; ...`. Escape `,` and `;` with `\\`. e.g. `tag1,tag2;tag3,tag4`",
                 value=config.get("wd14_caption.tag_replacement", ""),
                 interactive=True,
             )


### PR DESCRIPTION
## Summary
- fix folder structure documentation links in `common_gui.py`
- make caption replacement textbox info string raw

## Testing
- `pytest -q` in `sd-scripts`

------
https://chatgpt.com/codex/tasks/task_e_684c784ca9a883338b32c3ae74f7b80a